### PR TITLE
Fix GitHub Actions output syntax and test exit code handling

### DIFF
--- a/.github/workflows/qa_testing.yml
+++ b/.github/workflows/qa_testing.yml
@@ -61,8 +61,10 @@ jobs:
       continue-on-error: true
       run: |
         pytest tests/ --cov=backend --cov=database --cov-report=xml --cov-report=html --cov-report=term -v > test_output.txt 2>&1
-        echo "::set-output name=exit_code::$?"
+        TEST_EXIT_CODE=$?
+        echo "exit_code=$TEST_EXIT_CODE" >> $GITHUB_OUTPUT
         cat test_output.txt
+        exit $TEST_EXIT_CODE
     
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary
Updated the QA testing workflow to use the correct GitHub Actions output syntax and properly propagate test exit codes.

## Key Changes
- Replaced deprecated `::set-output` syntax with the newer `$GITHUB_OUTPUT` environment variable approach
- Stored pytest exit code in a variable before echoing to ensure it's captured correctly
- Added explicit `exit` command to propagate the test exit code, ensuring the workflow step fails when tests fail

## Implementation Details
The changes address two issues:
1. **GitHub Actions API Update**: The `::set-output` command was deprecated in favor of appending to the `$GITHUB_OUTPUT` file, which is the current recommended approach
2. **Exit Code Propagation**: Since the step has `continue-on-error: true`, the exit code wasn't being propagated. By explicitly calling `exit $TEST_EXIT_CODE` at the end, the step will now correctly report success/failure to downstream jobs while still allowing the workflow to continue if needed

https://claude.ai/code/session_01XLZT76CoqyuN1igg2zWD1a