### PR TITLE
ci: create PRs automatically when branch tests pass

### DIFF
--- a/.github/workflows/qa_testing.yml
+++ b/.github/workflows/qa_testing.yml
@@ -2,7 +2,8 @@ name: Autonomous QA Testing with Auto-Fix PRs
 
 on:
   push:
-    branches: [ main, develop ]
+    branches:
+      - '**'
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
@@ -200,6 +201,40 @@ jobs:
           testing
           qa-council
         assignees: ${{ github.actor }}
+
+    - name: Create PR for Passing Test Branch
+      if: steps.unit_tests.outputs.exit_code == '0' && github.event_name == 'push' && github.ref_name != 'main' && github.ref_name != 'develop'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const head = `${owner}:${context.ref.replace('refs/heads/', '')}`;
+          const base = 'develop';
+
+          const existing = await github.rest.pulls.list({
+            owner,
+            repo,
+            state: 'open',
+            head,
+            base
+          });
+
+          if (existing.data.length > 0) {
+            core.info(`Open PR already exists: #${existing.data[0].number}`);
+            return;
+          }
+
+          const pr = await github.rest.pulls.create({
+            owner,
+            repo,
+            title: `✅ QA Passed: ${context.ref.replace('refs/heads/', '')}`,
+            head: context.ref.replace('refs/heads/', ''),
+            base,
+            body: `## ✅ QA Council - Tests Passed\n\nAll unit tests passed for branch \`${context.ref.replace('refs/heads/', '')}\`.\n\n- Trigger: ${context.eventName}\n- Run ID: ${context.runId}\n- Workflow: ${context.workflow}\n\nThis PR was automatically opened because the test suite passed.`
+          });
+
+          core.info(`Created PR #${pr.data.number}`);
     
     - name: Comment on PR (if PR event)
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Motivation
- The workflow previously only created a pull request when unit tests failed, so branches with passing tests never opened an automated PR for integration. 
- Push events were limited to `main` and `develop`, so feature-branch pushes were not evaluated by the QA workflow. 

### Description
- Updated the workflow push trigger to run on all branches by changing `push` branches to `- '**'` so feature-branch pushes run the QA job. 
- Added a `Create PR for Passing Test Branch` step that runs when `steps.unit_tests.outputs.exit_code == '0'` and the event is `push` for branches other than `main` and `develop`, which checks for an existing open PR and creates one targeting `develop` only if none exists. 
- Left the existing test-failure PR creation intact and validated that the workflow YAML remains parseable and syntactically correct. 

### Testing
- Parsed the workflow YAML using Ruby with `YAML.load_file('.github/workflows/qa_testing.yml')` and the parse completed successfully. 
- Reviewed the workflow changes (diff) to confirm the new trigger and PR-creation step are present and conditional logic is correct. 
- Displayed the updated workflow file to verify placement and structure of the new `Create PR for Passing Test Branch` step, and no YAML errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69929f5ffd788325b9a0b872c62d76da)